### PR TITLE
Expanded error logging

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -16,7 +16,10 @@ type ErrorResponse struct {
 }
 
 func (e ErrorResponse) Error() string {
-	byt, _ := json.Marshal(e)
+	byt, err := json.Marshal(e)
+	if err != nil {
+		return fmt.Sprintf("error marshaling ErrorResponse: %v - original error message: %v", err, e.Message)
+	}
 	return string(byt)
 }
 

--- a/errors.go
+++ b/errors.go
@@ -2,6 +2,7 @@ package contentful
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 )
@@ -15,7 +16,8 @@ type ErrorResponse struct {
 }
 
 func (e ErrorResponse) Error() string {
-	return e.Message
+	byt, _ := json.Marshal(e)
+	return string(byt)
 }
 
 // Error defines an internal contentful data model error when e.g. an assets can


### PR DESCRIPTION
ErrorResponse contains a lot of useful information that is not visible in error() output. Marshal the object and print that.