### PR TITLE
feat: add region support for API base URLs

### DIFF
--- a/contentful.go
+++ b/contentful.go
@@ -40,14 +40,6 @@ type Contentful struct {
 	Webhooks     *WebhooksService
 }
 
-// Region identifies a Contentful infrastructure region.
-type Region string
-
-const (
-	RegionUS Region = "us"
-	RegionEU Region = "eu"
-)
-
 type service struct {
 	c *Contentful
 }

--- a/contentful.go
+++ b/contentful.go
@@ -48,20 +48,6 @@ const (
 	RegionEU Region = "eu"
 )
 
-// SetRegion configures all API base URLs for the given region.
-// RegionUS and the empty string are no-ops; the client keeps its constructor defaults.
-func (c *Contentful) SetRegion(region Region) *Contentful {
-	if region == "" || region == RegionUS {
-		return c
-	}
-	subdomain := "." + string(region)
-	c.BaseURL = strings.Replace(c.BaseURL, ".contentful.com", subdomain+".contentful.com", 1)
-	if c.UploadURL != "" {
-		c.UploadURL = strings.Replace(c.UploadURL, ".contentful.com", subdomain+".contentful.com", 1)
-	}
-	return c
-}
-
 type service struct {
 	c *Contentful
 }
@@ -151,6 +137,20 @@ func NewCPA(token string) *Contentful {
 	c.Locales = &LocalesService{c: c}
 	c.Webhooks = &WebhooksService{c: c}
 
+	return c
+}
+
+// SetRegion configures all API base URLs for the given region.
+// RegionUS and the empty string are no-ops; the client keeps its constructor defaults.
+func (c *Contentful) SetRegion(region Region) *Contentful {
+	if region == "" || region == RegionUS {
+		return c
+	}
+	subdomain := "." + string(region)
+	c.BaseURL = strings.Replace(c.BaseURL, ".contentful.com", subdomain+".contentful.com", 1)
+	if c.UploadURL != "" {
+		c.UploadURL = strings.Replace(c.UploadURL, ".contentful.com", subdomain+".contentful.com", 1)
+	}
 	return c
 }
 

--- a/contentful.go
+++ b/contentful.go
@@ -40,6 +40,28 @@ type Contentful struct {
 	Webhooks     *WebhooksService
 }
 
+// Region identifies a Contentful infrastructure region.
+type Region string
+
+const (
+	RegionUS Region = "us"
+	RegionEU Region = "eu"
+)
+
+// SetRegion configures all API base URLs for the given region.
+// RegionUS and the empty string are no-ops; the client keeps its constructor defaults.
+func (c *Contentful) SetRegion(region Region) *Contentful {
+	if region == "" || region == RegionUS {
+		return c
+	}
+	subdomain := "." + string(region)
+	c.BaseURL = strings.Replace(c.BaseURL, ".contentful.com", subdomain+".contentful.com", 1)
+	if c.UploadURL != "" {
+		c.UploadURL = strings.Replace(c.UploadURL, ".contentful.com", subdomain+".contentful.com", 1)
+	}
+	return c
+}
+
 type service struct {
 	c *Contentful
 }

--- a/contentful_test.go
+++ b/contentful_test.go
@@ -166,6 +166,35 @@ func TestContentfulSetOrganization(t *testing.T) {
 	assert.Equal(t, organizationID, cma.Headers["X-Contentful-Organization"])
 }
 
+func TestSetRegion(t *testing.T) {
+	t.Run("US is a no-op on CMA", func(t *testing.T) {
+		c := NewCMA(CMAToken)
+		c.SetRegion(RegionUS)
+		assert.Equal(t, "https://api.contentful.com", c.BaseURL)
+		assert.Equal(t, "https://upload.contentful.com", c.UploadURL)
+	})
+	t.Run("EU sets CMA BaseURL and UploadURL", func(t *testing.T) {
+		c := NewCMA(CMAToken)
+		c.SetRegion(RegionEU)
+		assert.Equal(t, "https://api.eu.contentful.com", c.BaseURL)
+		assert.Equal(t, "https://upload.eu.contentful.com", c.UploadURL)
+	})
+	t.Run("EU sets CDA BaseURL", func(t *testing.T) {
+		c := NewCDA(CDAToken)
+		c.SetRegion(RegionEU)
+		assert.Equal(t, "https://cdn.eu.contentful.com", c.BaseURL)
+	})
+	t.Run("EU sets CPA BaseURL", func(t *testing.T) {
+		c := NewCPA(CPAToken)
+		c.SetRegion(RegionEU)
+		assert.Equal(t, "https://preview.eu.contentful.com", c.BaseURL)
+	})
+	t.Run("SetRegion is chainable", func(t *testing.T) {
+		c := NewCMA(CMAToken).SetRegion(RegionEU)
+		assert.Equal(t, "https://api.eu.contentful.com", c.BaseURL)
+	})
+}
+
 func TestContentfulSetClient(t *testing.T) {
 	newClient := &http.Client{}
 	cma := NewCMA(CMAToken)

--- a/region.go
+++ b/region.go
@@ -13,9 +13,10 @@ const (
 // ParseRegion validates s against the known regions and returns the typed Region.
 // An empty string is accepted and represents the default (US) region.
 func ParseRegion(s string) (Region, error) {
-	switch Region(s) {
+	r := Region(s)
+	switch r {
 	case "", RegionUS, RegionEU:
-		return Region(s), nil
+		return r, nil
 	default:
 		return "", fmt.Errorf("unknown region %q: supported values are %q and %q", s, RegionUS, RegionEU)
 	}

--- a/region.go
+++ b/region.go
@@ -1,0 +1,22 @@
+package contentful
+
+import "fmt"
+
+// Region identifies a Contentful infrastructure region.
+type Region string
+
+const (
+	RegionUS Region = "us"
+	RegionEU Region = "eu"
+)
+
+// ParseRegion validates s against the known regions and returns the typed Region.
+// An empty string is accepted and represents the default (US) region.
+func ParseRegion(s string) (Region, error) {
+	switch Region(s) {
+	case "", RegionUS, RegionEU:
+		return Region(s), nil
+	default:
+		return "", fmt.Errorf("unknown region %q: supported values are %q and %q", s, RegionUS, RegionEU)
+	}
+}

--- a/region_test.go
+++ b/region_test.go
@@ -1,0 +1,34 @@
+package contentful
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRegion(t *testing.T) {
+	t.Run("empty string is valid", func(t *testing.T) {
+		r, err := ParseRegion("")
+		require.NoError(t, err)
+		assert.Equal(t, Region(""), r)
+	})
+	t.Run("us is valid", func(t *testing.T) {
+		r, err := ParseRegion("us")
+		require.NoError(t, err)
+		assert.Equal(t, RegionUS, r)
+	})
+	t.Run("eu is valid", func(t *testing.T) {
+		r, err := ParseRegion("eu")
+		require.NoError(t, err)
+		assert.Equal(t, RegionEU, r)
+	})
+	t.Run("uppercase EU is rejected", func(t *testing.T) {
+		_, err := ParseRegion("EU")
+		require.Error(t, err)
+	})
+	t.Run("unknown region is rejected", func(t *testing.T) {
+		_, err := ParseRegion("ap")
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
### Description

Adds Region support to the Contentful client. A new SetRegion setter method allows switching all API base URLs to the corresponding regional endpoint (e.g. EU) without touching constructor signatures or breaking any existing code.

### Type of Change

<!-- Check the relevant option -->

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance
- [x] ✅ Tests
- [ ] 🔧 Build/CI

## Changes

- Added Region string type with RegionUS = "us" and RegionEU = "eu" constants
- Added SetRegion(region Region) *Contentful method on the client — rewrites BaseURL and UploadURL (CMA only) to the regional subdomain via a single strings.Replace
- SetRegion("") and SetRegion(RegionUS) are strict no-ops — the client returns unchanged, all existing call sites are unaffected
- Method is chainable: contentful.NewCDA(key).SetRegion(RegionEU)
- Added TestSetRegion covering all four endpoints (CMA, CMA upload, CDA, CPA), the no-op guarantee, and chainability

### Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
